### PR TITLE
extra quotes removed on html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
   </div>
   {% include footer.html %}
   {% include sub-footer.html %}
-  <script type="text/javascript" src="{{ "/assets/js/scripts.js" | relative_url }}""></script>
+  <script type="text/javascript" src="{{ "/assets/js/scripts.js" | relative_url }}"></script>
   {% include google-analytics.html %}
 </body>
 </html>


### PR DESCRIPTION
This was making an invalid html syntax that was not producing an obvious error. Found by testing links on the page with [html-proofer](https://github.com/gjtorikian/html-proofer).